### PR TITLE
feat: update image lifecycle policy to protect prod images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # argus-artifacts
+
+Location of binaries and compiled GH actions produced by Argus and used by internal customers.
+
+## Code of Conduct
+
+This project adheres to the Contributor Covenant [code of conduct](https://github.com/chanzuckerberg/.github/blob/master/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [opensource@chanzuckerberg.com](mailto:opensource@chanzuckerberg.com).

--- a/settings/ecr/lifecycle-policy.json
+++ b/settings/ecr/lifecycle-policy.json
@@ -2,11 +2,42 @@
   "rules": [
     {
       "rulePriority": 1,
-      "description": "Keep at most 1000 images",
+      "description": "Keep production images forever",
       "selection": {
-        "tagStatus": "any",
+        "tagStatus": "tagged",
+        "tagPatternList": [
+          "prod*"
+        ],
+        "countType": "imageCountMoreThan",
+        "countNumber": 999999
+      },
+      "action": {
+        "type": "expire"
+      }
+    },
+    {
+      "rulePriority": 2,
+      "description": "Keep latest 1000 of all other tagged images",
+      "selection": {
+        "tagStatus": "tagged",
+        "tagPatternList": [
+          "*"
+        ],
         "countType": "imageCountMoreThan",
         "countNumber": 1000
+      },
+      "action": {
+        "type": "expire"
+      }
+    },
+    {
+      "rulePriority": 3,
+      "description": "Clean up old untagged images",
+      "selection": {
+        "tagStatus": "untagged",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 7
       },
       "action": {
         "type": "expire"


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-5211

## Summary

This updates our image lifecycle policy so that images tagged with "prod*" will be kept around for longer than images not tagged with "prod". Images get tagged with "production" during the [docker-build-push action](https://github.com/chanzuckerberg/github-actions/pull/440).

## References

* https://github.com/chanzuckerberg/github-actions/pull/440