### PR TITLE
chore: upgrade GitHub Actions from node20 to node24

### DIFF
--- a/.github/workflows/create-major-minor-tags.yml
+++ b/.github/workflows/create-major-minor-tags.yml
@@ -9,19 +9,19 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.GH_ACTIONS_HELPER_APP_ID }}
           private-key: ${{ secrets.GH_ACTIONS_HELPER_PK }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - name: Install semver
         run: npm install semver
       - name: Parse Version
         id: parse_version
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const semver = require('semver')
@@ -33,7 +33,7 @@ jobs:
               throw new Error(`Invalid version: ${version}`)
             }
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.generate_token.outputs.token }}
           ref: ${{ github.ref }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -15,27 +15,27 @@ jobs:
       # For why we need to generate a token and not use the default
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.GH_ACTIONS_HELPER_APP_ID }}
           private-key: ${{ secrets.GH_ACTIONS_HELPER_PK }}
           repositories: argus,argus-artifacts,homebrew-tap
 
       # clone the artifact repo
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.generate_token.outputs.token }}
           path: ${{ github.event.repository.name }}
 
       # clone the source repo
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.generate_token.outputs.token }}
           repository: chanzuckerberg/${{ env.SOURCE_REPO }}
           # we need to clone the source repo into a directory within the artifact repo so that goreleaser will build the source but use the tag from the artifact repo
           path: ${{ github.event.repository.name }}/core/cli/${{ env.SOURCE_REPO }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: ${{ github.event.repository.name }}/core/cli/${{ env.SOURCE_REPO }}/core/go.mod
           cache: true


### PR DESCRIPTION
GitHub is deprecating node20 on runners (mandatory June 2, 2026). This PR upgrades all GitHub Actions workflow files and custom action.yml files from node20 to node24 runtimes, and updates action dependencies to their node24-compatible versions.

Created by [PatchStorm skill](https://github.com/chanzuckerberg/infra-skills/tree/main/skills/patchstorm)

Made with [Cursor](https://cursor.com)